### PR TITLE
Update link to point to CLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Thanks for considering to contribute to the Modelon Software. 
 
-All contributions are accepted under the terms of the Contributor License Agreement available at https://github.com/modelon/contributing. The process is mandatory in order to avoid any external Copyright claims and potential redistribution license violation. 
+All contributions are accepted under the terms of the [Contributor License Agreement](https://github.com/modelon/contributing/blob/master/Modelon-Contributor%20License%20Agreement%202016.pdf). The process is mandatory in order to avoid any external Copyright claims and potential redistribution license violation. 
 
 Please, download and review the document. If you are comfortable with the terms, print out and sign the agreement. Please, send a copy of the signed agreement along with your Github ID to modelon-community@modelon.com to be kept for our records.


### PR DESCRIPTION
The link in README.md was referencing itself. I believe it should be the CLA instead.